### PR TITLE
:bug: Fix broken links

### DIFF
--- a/404.md
+++ b/404.md
@@ -5,14 +5,6 @@ description: "Page not found"
 sitemap: false
 search_omit: true
 permalink: /404.html
----  
+---
 
-Sorry, but the page you were trying to view does not exist --- perhaps you can try searching for it below.
-
-<script type="text/javascript">
-  var GOOG_FIXURL_LANG = 'en';
-  var GOOG_FIXURL_SITE = '{{ site.url }}'
-</script>
-<script type="text/javascript"
-  src="//linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js">
-</script>
+Sorry, but the page you were trying to view does not exist! :see_no_evil:

--- a/_posts/blog/2019-10-17-diving-into-leadership.md
+++ b/_posts/blog/2019-10-17-diving-into-leadership.md
@@ -30,7 +30,7 @@ So, what is this "Binder" that we're all so excited about?
 
 [Binder](https://mybinder.readthedocs.io/en/latest/) is an amazing resource that can host reproducible and interactive code in a web browser. Great... what does that mean? It means that if I have some scripts or notebooks in a repository (like [this one](https://github.com/binder-examples/requirements)) and I describe the packages in a configuration file (such as [`requirements.txt`](https://github.com/binder-examples/requirements/blob/master/requirements.txt)), then I can go to [mybinder.org](https://mybinder.org), copy the URL of the repository into the form and hit launch. This will begin a series of events culminating in my notebook appearing in a browser window with all of the packages installed, and the code will _just run_.
 
-Sounds like magic, right? You can even combine Binder with [Jupyter Books](https://jupyter.org/jupyter-book/intro.html) to create [interactive documents](https://joergbrech.github.io/Modellbildung-und-Simulation/intro)! Below is a comic explaining how a scientist may use Binder.
+Sounds like magic, right? You can even combine Binder with [Jupyter Books](https://jupyterbook.org) to create [interactive documents](https://joergbrech.github.io/Modellbildung-und-Simulation/intro)! Below is a comic explaining how a scientist may use Binder.
 
 | <img src="https://pbs.twimg.com/media/DwYDGULWkAASgjS.jpg" alt="Binder comic"> |
 | :---: |


### PR DESCRIPTION
### Summary

Green-flagging the CI build by fixing broken links

### What's changed?

External links fixed in:

- Diving into Leadership blog
- Search script removed from `404.md` which contained a broken link

### What should a reviewer concentrate their feedback on?

- [x] Everything looks ok?
