### PR TITLE
Configure spellcheck to check only Markdown file

### DIFF
--- a/spellcheck.yaml
+++ b/spellcheck.yaml
@@ -1,0 +1,24 @@
+- name: Markdown
+  expect_match: false
+  apsell:
+    mode: en
+  dictionary:
+    wordlists:
+    - wordlist.txt
+    output: wordlist.dic
+    encoding: utf-8
+  pipeline:
+  - pyspelling.filters.markdown:
+      markdown_extensions:
+      - markdown.extensions.extra:
+  - pyspelling.filters.html:
+      comments: true
+      attributes:
+      - title
+      - alt
+      ignores:
+      - ':matches(code, pre)'
+      - 'code'
+      - 'pre'
+  sources:
+  - '**/*.md'


### PR DESCRIPTION
### Summary

Add spellcheck configuration so only Markdown files are checked.

### What's changed?

- Added `spellcheck.yaml`

### What should a reviewer concentrate their feedback on?

- [x] Everything looks ok?
