### PR TITLE
Use an App-generated token to open PRs

### DIFF
--- a/.github/workflows/autoupdate-theme.yaml
+++ b/.github/workflows/autoupdate-theme.yaml
@@ -8,12 +8,20 @@ on:
 jobs:
   autoupdate-theme:
     runs-on: ubuntu-latest
+    environment: github-app-token
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
           submodules: true
+
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Run git submodule command
         run: |
@@ -27,3 +35,4 @@ jobs:
           title: Update website theme
           body: "Automated update of git submodule that contains the website theme"
           labels: website
+          token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Now when the autoupdate theme workflow runs in the future, the PR opened by it should also trigger the test suite in GitHub Actions. Once the test suite passes, mergify should automatically merge the PR, hence fully automating the process of keeping the theme up-to-date.