### PR TITLE
Add announcement that the hugo tutorial has moved

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -104,6 +104,7 @@ gitmoji
 see_no_evil
 hear_no_evil
 speak_no_evil
+github.io
  - CODE_OF_CONDUCT.md
 i
 o

--- a/content/blog/hugo-tutorial.md
+++ b/content/blog/hugo-tutorial.md
@@ -14,6 +14,10 @@ Whether you're looking to strike up new collaborations or promote your freshly p
 
 I put together a tutorial for building a blog site from scratch using [Hugo](https://gohugo.io/) and [GitHub Pages](https://pages.github.com/) - the same tools I use to host this site!
 
+> :information: **The website has moved!**
+>
+> This lesson has now been transferred to the [Carpentries Incubator](https://carpentries-incubator.org/) and can be found here: [carpentries-incubator.github.io/blogging-with-hugo-and-github-pages/](https://carpentries-incubator.github.io/blogging-with-hugo-and-github-pages/)
+
 - :sparkles: You can find the written instructions here: [sgibson91.github.io/blogging-with-hugo-and-github-pages/](https://sgibson91.github.io/blogging-with-hugo-and-github-pages/)
 - :sparkles: You can also follow along with the YouTube video below.
   I go quite fast :rocket: so feel free to pause and rewind as much as you need!


### PR DESCRIPTION
My hugo tutorial has moved to the Carpentries Incubator. This PR adds an update to the associated blog with the new link